### PR TITLE
build: 添加 Dockerfile 和 docker-compose.yaml 文件

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM golang:alpine AS builder
+
+LABEL stage=gobuilder
+
+ENV GOPROXY=https://goproxy.cn,direct
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
+
+RUN apk update --no-cache && apk add --no-cache tzdata
+
+WORKDIR /build
+
+ADD go.mod .
+ADD go.sum .
+RUN go mod download
+COPY . .
+RUN go build -ldflags="-s -w" -o /app/neko-acm main.go
+
+FROM alpine
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /usr/share/zoneinfo/Asia/Shanghai /usr/share/zoneinfo/Asia/Shanghai
+ENV TZ=Asia/Shanghai
+
+WORKDIR /app
+COPY --from=builder /app/neko-acm /app/neko-acm
+
+CMD ["./neko-acm","server"]
+
+EXPOSE 14515/tcp

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+    neko-acm:
+        container_name: neko-acm
+        image: neko-acm
+        restart: no
+        volumes:
+            - ./config.yaml:/app/config.yaml
+        ports:
+            - 14515:14515


### PR DESCRIPTION
- 新增 Dockerfile 用于构建 neko-acm 镜像
- 新增 docker-compose.yaml 用于部署 neko-acm 容器
- 配置 Go 代理、时区等环境
- 优化镜像大小和构建过程